### PR TITLE
fix: 当服务端关闭连或重启时，陷入没有动作的死循环

### DIFF
--- a/python-ngrok_deepseek.py
+++ b/python-ngrok_deepseek.py
@@ -605,8 +605,7 @@ class NgrokClient:
             while self.running:
                 msg = await self._recv_packet(self.main_reader)
                 if not msg:
-                    self.last_ping = time.time()
-                    await asyncio.sleep(1)
+                    raise ConnectionError("服务端关闭了连接")
                 await self._process_message(msg)
         except (asyncio.IncompleteReadError, ConnectionError) as e:
             logger.debug(f"连接中断: {str(e)}")


### PR DESCRIPTION
发现一个问题,当服务端完全重启时，TCP 连接会断开，Python 的 reader.read() 会收到一个空数据（EOF），表示连接已关闭。此时，代码中的 _recv_loop（消息接收循环）处理逻辑有误，导致它没有退出，而是进入了一个假装还活着的死循环。
修改内容： 将 _recv_loop 中处理 EOF（空消息）的逻辑从“休眠并假装正常”改为“抛出 ConnectionError”。
预期行为变更： 现在，当服务端重启或网络断开导致 TCP 关闭时：
1. _recv_packet 返回 None。
2. 代码抛出ConnectionError("服务端关闭了连接")。
3. _recv_loop 退出并设置 self.running = False。
4. start() 中的 finally 块触发资源清理。
5. while True 循环进入下一次迭代，调用 _connect_with_retry() 重新连接服务端。
